### PR TITLE
Fix the gold index issue in fetching logprob

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Generation is performed via top-k/random sampling.
 `python translate.py -beam_size 1 -random_sampling_topk 100 -random_sampling_temp 0.9 -model <path/to/model.pt> -src data/stories/test.wp_source.bpe -max_length 1000 -verbose`
 
 Evaluate perplexity with test target.
+
 `python translate.py -beam_size 1 -random_sampling_topk 100 -random_sampling_temp 0.9 -model <path/to/model.pt> -src data/stories/test.wp_source.bpe -tgt data/stories/test.wp_target.bpe -max_length 1000 -verbose -seed 111`
 
 ## Image captioning

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ Generation is performed via top-k/random sampling.
 
 `python translate.py -beam_size 1 -random_sampling_topk 100 -random_sampling_temp 0.9 -model <path/to/model.pt> -src data/stories/test.wp_source.bpe -max_length 1000 -verbose`
 
+Evaluate perplexity with test target.
+`python translate.py -beam_size 1 -random_sampling_topk 100 -random_sampling_temp 0.9 -model <path/to/model.pt> -src data/stories/test.wp_source.bpe -tgt data/stories/test.wp_target.bpe -max_length 1000 -verbose -seed 111`
+
 ## Image captioning
 
 Coming soon...

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -898,7 +898,7 @@ class Translator(object):
             memory_lengths=src_lengths, src_map=src_map)
 
         log_probs[:, :, self._tgt_pad_idx] = 0
-        gold = tgt_in
+        gold = tgt[1:]
         gold_scores = log_probs.gather(2, gold)
         gold_scores = gold_scores.sum(dim=0).view(-1)
 


### PR DESCRIPTION
In story generation task, the original code fetches incorrect index of "logprob", leading to incorrect perplexity evaluation. 

Originally:
     tgt_in = tgt[:-1]
     log_probs, attn = ...
     ...
     gold = tgt_in

Edited:
     tgt_in = tgt[:-1]
     log_probs, attn = ...
     ...
     gold = tgt[1:]
 